### PR TITLE
feat: file icons

### DIFF
--- a/src/components/explorer/File.jsx
+++ b/src/components/explorer/File.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import {
+    Avatar,
     Card,
     CardHeader,
     Grid,
@@ -11,7 +12,6 @@ import {
     MenuItem,
     Typography,
 } from "@mui/material";
-import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FileUploadIcon from "@mui/icons-material/FileUpload";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
@@ -19,6 +19,7 @@ import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import client from "../../services/telegram";
 import ProgressCircle from "../ProgressCircle";
 import downloadFile from "../../utils/downloadFile";
+import getFileIcon from "../../utils/getFileIcon";
 
 // eslint-disable-next-line react-refresh/only-export-components
 function File(props) {
@@ -55,7 +56,7 @@ function File(props) {
         <Grid item key={id}>
             <Card>
                 <CardHeader
-                    avatar={<InsertDriveFileIcon />}
+                    avatar={<Avatar height="48" src={getFileIcon(name)} />}
                     action={
                         <IconButton onClick={handleClick}>
                             <MoreVertIcon />

--- a/src/utils/getFileIcon.js
+++ b/src/utils/getFileIcon.js
@@ -1,0 +1,41 @@
+export default function getFileIcon(filename) {
+    const fileExtension = filename.split('.').reverse()[0]
+
+    if (fileTypesMap.image.includes(fileExtension)) {
+        return iconsMap.image;
+    }
+
+    if (fileTypesMap.audio.includes(fileExtension)) {
+        return iconsMap.audio;
+    }
+
+    if (fileTypesMap.video.includes(fileExtension)) {
+        return iconsMap.video;
+    }
+
+    if (fileTypesMap.document.includes(fileExtension)) {
+        return iconsMap.document;
+    }
+
+    if (fileTypesMap.archive.includes(fileExtension)) {
+        return iconsMap.archive;
+    }
+    return iconsMap.misc;
+}
+
+const iconsMap = {
+    image: 'https://img.icons8.com/fluency/48/image.png',
+    audio: 'https://img.icons8.com/color/48/audio-file.png',
+    video: 'https://img.icons8.com/color/48/cinema---v1.png',
+    document: 'https://img.icons8.com/color/48/document--v1.png',
+    archive: 'https://img.icons8.com/color/48/archive.png',
+    misc: 'https://img.icons8.com/color/48/file.png'
+}
+
+const fileTypesMap = {
+    image: ['png', 'jpg', 'jpeg', 'gif', 'webp'],
+    audio: ['mp3', 'aac', 'wav'],
+    video: ['mp4', 'webm', 'mkv'],
+    document: ['pdf', 'doc', 'xls', 'xlsx'],
+    archive: ['iso', 'zip', 'rar', 'tar', 'tar.gz']
+}


### PR DESCRIPTION
**This PR adds the functionality for files to have different file icons based on their extension type.**

![image](https://github.com/MQ-xz/CloudGram/assets/60477442/8fc908d9-dcae-407c-ac32-7bc879582806)

# 

**Added Icons for**
- [x] Images
- [x] Documents
- [x] Videos
- [x] Audios
- [x] Misc (other files) 

# 

Icon Courtesy: [Icons8](https://icons8.com)